### PR TITLE
Added retry for failed requests

### DIFF
--- a/albumnotify.py
+++ b/albumnotify.py
@@ -32,8 +32,21 @@ def requests_get_cached(url):
     if not os.path.exists(cached_filename):
         # https://python-musicbrainzngs.readthedocs.org/en/latest/api/#general
         # musicbrainzngs.set_rate_limit(limit_or_interval=1.0, new_requests=1)
-        time.sleep(1)
-        resp = requests.get(url)
+        status_code = 0
+        delay = 1
+        retry_attempts = 10
+        for i in range(retry_attempts):
+            time.sleep(delay)
+            delay *= 1.9
+            resp = requests.get(url)
+
+            if resp.status_code == 200:
+                break
+            print "Got status code #{}, retrying (attempt {}/{})...".format(resp.status_code, i+2, retry_attempts)
+
+        if resp.status_code != 200:
+            raise IOError("Can't fetch url %s" % url)
+
         result = resp.text.encode('utf-8')
         file_put(cached_filename, result)
     return file_get(cached_filename)


### PR DESCRIPTION
Sometimes musicbrainz API doesn't work for a moment but works if you make another request. Unfortunately, current downloader doesn't account for that, which leads to errors (which get persisted by a cache).

This PR introduces exponential backoff retries into the process: the script will make up to 10 retries per url, each next retry will be preceded with a delay, 1.9 times longer than the previous one.
